### PR TITLE
Add DRG construction, validation, and dsntk val command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,7 @@ dependencies = [
  "oxc_ast",
  "oxc_parser",
  "oxc_span",
+ "petgraph",
  "serde",
  "serde_json",
  "serde_yml",

--- a/dsntk/src/actions.rs
+++ b/dsntk/src/actions.rs
@@ -119,10 +119,16 @@ const COMMAND_EXS: AppCommand = AppCommand {
   display_order: 15,
 };
 
+const COMMAND_VAL: AppCommand = AppCommand {
+  name: "val",
+  about: "Validate a markdown DMN project",
+  display_order: 16,
+};
+
 const COMMAND_NEW: AppCommand = AppCommand {
   name: "new",
   about: "Create a new project from a template",
-  display_order: 16,
+  display_order: 17,
 };
 
 /// Supported decision table input file formats.
@@ -265,6 +271,11 @@ enum Action {
     /// Check-only mode (validate without listing).
     bool,
   ),
+  /// Validate a markdown DMN project.
+  ValidateProject(
+    /// Directory containing the DMN project.
+    String,
+  ),
   /// Save examples.
   SaveExamples(
     /// Directory where examples are saved.
@@ -342,6 +353,10 @@ pub async fn do_action() -> std::io::Result<()> {
     }
     Action::ListTypes(dir, check_only) => {
       list_types(&dir, check_only);
+      Ok(())
+    }
+    Action::ValidateProject(dir) => {
+      validate_project(&dir);
       Ok(())
     }
     Action::SaveExamples(root_dir) => {
@@ -651,6 +666,13 @@ fn get_matches() -> ArgMatches {
         )
         .arg(arg!(<DIR>).help("Directory containing DMN project files").required(true).index(1)),
     )
+    // val - Validate a markdown DMN project
+    .subcommand(
+      Command::new(COMMAND_VAL.name)
+        .about(COMMAND_VAL.about)
+        .display_order(COMMAND_VAL.display_order)
+        .arg(arg!(<DIR>).help("Directory containing DMN project files").required(false).default_value(".").index(1)),
+    )
     // exs - Save examples
     .subcommand(
       Command::new(COMMAND_EXS.name)
@@ -783,6 +805,10 @@ fn get_cli_action() -> Action {
     // list or check resolved types
     Some(("typ", matches)) => {
       return Action::ListTypes(match_string(matches, "DIR"), matches.get_flag("check"));
+    }
+    // validate a markdown DMN project
+    Some(("val", matches)) => {
+      return Action::ValidateProject(match_string(matches, "DIR"));
     }
     // generate examples
     Some(("exs", matches)) => {
@@ -1171,6 +1197,33 @@ fn export_dmn_model(dmn_file_name: &str, html_file_name: &str) {
       Err(reason) => eprintln!("ERROR: {reason}"),
     },
     Err(reason) => eprintln!("loading model file `{dmn_file_name}` failed with reason: {reason}"),
+  }
+}
+
+/// Validates a markdown DMN project by building and checking its Decision Requirements Graph.
+fn validate_project(dir: &str) {
+  let path = std::path::Path::new(dir);
+  match dsntk_type_registry::build_drg(path) {
+    Ok(drg) => {
+      let order = match drg.topological_order() {
+        Ok(order) => order,
+        Err(e) => {
+          eprintln!("Validation failed: {e}");
+          std::process::exit(1);
+        }
+      };
+      println!("Project is valid.");
+      println!("  Nodes: {}", drg.node_count());
+      println!("  Edges: {}", drg.edge_count());
+      println!("  Evaluation order:");
+      for (i, id) in order.iter().enumerate() {
+        println!("    {}. {id}", i + 1);
+      }
+    }
+    Err(e) => {
+      eprintln!("Validation failed: {e}");
+      std::process::exit(1);
+    }
   }
 }
 

--- a/type-registry/Cargo.toml
+++ b/type-registry/Cargo.toml
@@ -20,4 +20,5 @@ oxc_span = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
+petgraph = { workspace = true }
 walkdir = { workspace = true }

--- a/type-registry/src/errors.rs
+++ b/type-registry/src/errors.rs
@@ -70,6 +70,10 @@ pub fn err_drg_no_md_files(dir: &str) -> DsntkError {
   TypeRegistryError(format!("no markdown DMN files found in '{dir}'")).into()
 }
 
+pub fn err_drg_file_read(path: &str, message: &str) -> DsntkError {
+  TypeRegistryError(format!("failed to read '{path}': {message}")).into()
+}
+
 pub fn err_drg_invalid_edge_type(source_id: &str, link_key: &str, target_id: &str, expected_type: &str, actual_type: &str) -> DsntkError {
   TypeRegistryError(format!(
     "node '{source_id}' has '{link_key}' link to '{target_id}' which is type '{actual_type}', expected '{expected_type}'"

--- a/type-registry/src/errors.rs
+++ b/type-registry/src/errors.rs
@@ -53,3 +53,26 @@ pub fn err_bkm_invocation_arity(bkm_name: &str, expected: usize, actual: usize) 
 pub fn err_enum_violation(value: &str, allowed: &[String]) -> DsntkError {
   TypeRegistryError(format!("value '{value}' is not in allowed values: [{}]", allowed.join(", "))).into()
 }
+
+pub fn err_drg_cycle(cycle_path: &str) -> DsntkError {
+  TypeRegistryError(format!("cycle detected in decision requirements graph: {cycle_path}")).into()
+}
+
+pub fn err_drg_unresolved_link(source_file: &str, target_id: &str) -> DsntkError {
+  TypeRegistryError(format!("unresolved link in '{source_file}': target node '{target_id}' not found")).into()
+}
+
+pub fn err_drg_duplicate_node_id(id: &str, file1: &str, file2: &str) -> DsntkError {
+  TypeRegistryError(format!("duplicate node id '{id}' in '{file1}' and '{file2}'")).into()
+}
+
+pub fn err_drg_no_md_files(dir: &str) -> DsntkError {
+  TypeRegistryError(format!("no markdown DMN files found in '{dir}'")).into()
+}
+
+pub fn err_drg_invalid_edge_type(source_id: &str, link_key: &str, target_id: &str, expected_type: &str, actual_type: &str) -> DsntkError {
+  TypeRegistryError(format!(
+    "node '{source_id}' has '{link_key}' link to '{target_id}' which is type '{actual_type}', expected '{expected_type}'"
+  ))
+  .into()
+}

--- a/type-registry/src/graph.rs
+++ b/type-registry/src/graph.rs
@@ -7,7 +7,7 @@
 use crate::errors::*;
 use crate::front_matter::{parse_front_matter, DmnNode};
 use dsntk_common::Result;
-use petgraph::algo::{is_cyclic_directed, toposort};
+use petgraph::algo::toposort;
 use petgraph::graph::{DiGraph, NodeIndex};
 use std::collections::HashMap;
 use std::path::Path;
@@ -153,12 +153,10 @@ pub fn build_drg(project_dir: &Path) -> Result<Drg> {
     }
   }
 
-  // Phase 5: validate acyclicity
-  if is_cyclic_directed(&graph) {
-    if let Err(cycle) = toposort(&graph, None) {
-      let node_id = &graph[cycle.node_id()];
-      return Err(err_drg_cycle(node_id));
-    }
+  // Phase 5: validate acyclicity (toposort returns Err if a cycle exists)
+  if let Err(cycle) = toposort(&graph, None) {
+    let node_id = &graph[cycle.node_id()];
+    return Err(err_drg_cycle(node_id));
   }
 
   Ok(Drg { graph, node_index, nodes })
@@ -170,7 +168,7 @@ fn scan_md_files(dir: &Path) -> Result<Vec<DrgNode>> {
   for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
     let path = entry.path();
     if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("md") {
-      let content = std::fs::read_to_string(path).map_err(|e| err_drg_no_md_files(&format!("{}: {e}", path.display())))?;
+      let content = std::fs::read_to_string(path).map_err(|e| err_drg_file_read(&path.to_string_lossy(), &e.to_string()))?;
       // Skip .md files without front matter (e.g., README.md)
       if !content.trim_start().starts_with("---") {
         continue;

--- a/type-registry/src/graph.rs
+++ b/type-registry/src/graph.rs
@@ -1,0 +1,193 @@
+//! # Decision Requirements Graph (DRG) construction and validation
+//!
+//! Scans a markdown DMN project directory, parses front matter from all `.md` files,
+//! builds a petgraph DiGraph, validates structural constraints, and produces
+//! a topological evaluation order.
+
+use crate::errors::*;
+use crate::front_matter::{parse_front_matter, DmnNode};
+use dsntk_common::Result;
+use petgraph::algo::{is_cyclic_directed, toposort};
+use petgraph::graph::{DiGraph, NodeIndex};
+use std::collections::HashMap;
+use std::path::Path;
+use walkdir::WalkDir;
+
+/// The kind of edge in the DRG.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrgEdgeKind {
+  /// `requires` — information requirement (data flow).
+  InformationRequirement,
+  /// `governed-by` — authority requirement (→ knowledge-source).
+  AuthorityRequirement,
+  /// `supported-by` — knowledge requirement (→ BKM).
+  KnowledgeRequirement,
+}
+
+/// A parsed DMN node with its source file path.
+#[derive(Debug, Clone)]
+pub struct DrgNode {
+  pub dmn: DmnNode,
+  pub file_path: String,
+}
+
+/// The Decision Requirements Graph for a markdown DMN project.
+#[derive(Debug)]
+pub struct Drg {
+  graph: DiGraph<String, DrgEdgeKind>,
+  node_index: HashMap<String, NodeIndex>,
+  nodes: HashMap<String, DrgNode>,
+}
+
+impl Drg {
+  pub fn node_count(&self) -> usize {
+    self.graph.node_count()
+  }
+
+  pub fn edge_count(&self) -> usize {
+    self.graph.edge_count()
+  }
+
+  pub fn edge_kinds(&self) -> Vec<DrgEdgeKind> {
+    self.graph.edge_weights().copied().collect()
+  }
+
+  /// Returns node IDs in topological order (inputs first, terminal decisions last).
+  pub fn topological_order(&self) -> Result<Vec<String>> {
+    let sorted = toposort(&self.graph, None).map_err(|cycle| {
+      let node_id = &self.graph[cycle.node_id()];
+      err_drg_cycle(node_id)
+    })?;
+    let mut result: Vec<String> = sorted.into_iter().map(|idx| self.graph[idx].clone()).collect();
+    result.reverse();
+    Ok(result)
+  }
+
+  pub fn get_node(&self, id: &str) -> Option<&DrgNode> {
+    self.nodes.get(id)
+  }
+
+  pub fn node_ids(&self) -> Vec<String> {
+    self.node_index.keys().cloned().collect()
+  }
+}
+
+/// Scans a project directory for `.md` files, parses their front matter,
+/// and builds a validated DRG.
+pub fn build_drg(project_dir: &Path) -> Result<Drg> {
+  // Phase 1: scan and parse all .md files
+  let drg_nodes = scan_md_files(project_dir)?;
+  if drg_nodes.is_empty() {
+    return Err(err_drg_no_md_files(&project_dir.to_string_lossy()));
+  }
+
+  // Phase 2: build the graph — add all nodes
+  let mut graph: DiGraph<String, DrgEdgeKind> = DiGraph::new();
+  let mut node_index: HashMap<String, NodeIndex> = HashMap::new();
+  let mut nodes: HashMap<String, DrgNode> = HashMap::new();
+
+  for drg_node in &drg_nodes {
+    let id = &drg_node.dmn.id;
+    if let Some(existing) = nodes.get(id) {
+      return Err(err_drg_duplicate_node_id(id, &existing.file_path, &drg_node.file_path));
+    }
+    let idx = graph.add_node(id.clone());
+    node_index.insert(id.clone(), idx);
+    nodes.insert(id.clone(), drg_node.clone());
+  }
+
+  // Phase 3: add edges — validate all targets exist
+  for drg_node in &drg_nodes {
+    let source_idx = node_index[&drg_node.dmn.id];
+
+    if let Some(ref requires) = drg_node.dmn.requires {
+      for target_id in requires {
+        let target_idx = node_index.get(target_id).ok_or_else(|| err_drg_unresolved_link(&drg_node.file_path, target_id))?;
+        graph.add_edge(source_idx, *target_idx, DrgEdgeKind::InformationRequirement);
+      }
+    }
+
+    if let Some(ref governed_by) = drg_node.dmn.governed_by {
+      for target_id in governed_by {
+        let target_idx = node_index.get(target_id).ok_or_else(|| err_drg_unresolved_link(&drg_node.file_path, target_id))?;
+        graph.add_edge(source_idx, *target_idx, DrgEdgeKind::AuthorityRequirement);
+      }
+    }
+
+    if let Some(ref supported_by) = drg_node.dmn.supported_by {
+      for target_id in supported_by {
+        let target_idx = node_index.get(target_id).ok_or_else(|| err_drg_unresolved_link(&drg_node.file_path, target_id))?;
+        graph.add_edge(source_idx, *target_idx, DrgEdgeKind::KnowledgeRequirement);
+      }
+    }
+  }
+
+  // Phase 4: validate edge-type constraints
+  for drg_node in &drg_nodes {
+    let source_id = &drg_node.dmn.id;
+
+    if let Some(ref governed_by) = drg_node.dmn.governed_by {
+      for target_id in governed_by {
+        if let Some(target_node) = nodes.get(target_id) {
+          if target_node.dmn.node_type != "knowledge-source" {
+            return Err(err_drg_invalid_edge_type(
+              source_id,
+              "governed-by",
+              target_id,
+              "knowledge-source",
+              &target_node.dmn.node_type,
+            ));
+          }
+        }
+      }
+    }
+
+    if let Some(ref supported_by) = drg_node.dmn.supported_by {
+      for target_id in supported_by {
+        if let Some(target_node) = nodes.get(target_id) {
+          if target_node.dmn.node_type != "bkm" {
+            return Err(err_drg_invalid_edge_type(source_id, "supported-by", target_id, "bkm", &target_node.dmn.node_type));
+          }
+        }
+      }
+    }
+  }
+
+  // Phase 5: validate acyclicity
+  if is_cyclic_directed(&graph) {
+    if let Err(cycle) = toposort(&graph, None) {
+      let node_id = &graph[cycle.node_id()];
+      return Err(err_drg_cycle(node_id));
+    }
+  }
+
+  Ok(Drg { graph, node_index, nodes })
+}
+
+/// Recursively scans a directory for `.md` files and parses their front matter.
+fn scan_md_files(dir: &Path) -> Result<Vec<DrgNode>> {
+  let mut nodes = Vec::new();
+  for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+    let path = entry.path();
+    if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("md") {
+      let content = std::fs::read_to_string(path).map_err(|e| err_drg_no_md_files(&format!("{}: {e}", path.display())))?;
+      // Skip .md files without front matter (e.g., README.md)
+      if !content.trim_start().starts_with("---") {
+        continue;
+      }
+      match parse_front_matter(&content) {
+        Ok(fm) => {
+          nodes.push(DrgNode {
+            dmn: fm.dmn,
+            file_path: path.to_string_lossy().to_string(),
+          });
+        }
+        Err(_) => {
+          // Skip markdown files that have --- but don't have valid DMN front matter
+          continue;
+        }
+      }
+    }
+  }
+  Ok(nodes)
+}

--- a/type-registry/src/lib.rs
+++ b/type-registry/src/lib.rs
@@ -9,6 +9,7 @@ extern crate dsntk_macros;
 pub mod errors;
 pub mod exporter;
 pub mod front_matter;
+pub mod graph;
 pub mod json_schema_parser;
 pub mod primitive;
 pub mod registry;
@@ -20,4 +21,5 @@ pub mod ts_parser;
 mod tests;
 
 pub use front_matter::{parse_front_matter, BkmParameter, BkmSignature, DataTypeRef, DmnNode, DmnNodeType, FrontMatter};
+pub use graph::{build_drg, Drg, DrgEdgeKind, DrgNode};
 pub use registry::{TypeEntry, TypeRegistry, TypeSource};

--- a/type-registry/src/tests/fixtures/graph_bad_governed_by/decisions/not_a_ks.md
+++ b/type-registry/src/tests/fixtures/graph_bad_governed_by/decisions/not_a_ks.md
@@ -1,0 +1,6 @@
+---
+dmn:
+  id: not_a_ks
+  type: decision
+  name: Not A Knowledge Source
+---

--- a/type-registry/src/tests/fixtures/graph_bad_governed_by/decisions/pricing.md
+++ b/type-registry/src/tests/fixtures/graph_bad_governed_by/decisions/pricing.md
@@ -1,0 +1,8 @@
+---
+dmn:
+  id: pricing
+  type: decision
+  name: Pricing
+  governed-by:
+    - not_a_ks
+---

--- a/type-registry/src/tests/fixtures/graph_bad_supported_by/decisions/pricing.md
+++ b/type-registry/src/tests/fixtures/graph_bad_supported_by/decisions/pricing.md
@@ -1,0 +1,8 @@
+---
+dmn:
+  id: pricing
+  type: decision
+  name: Pricing
+  supported-by:
+    - not_a_bkm
+---

--- a/type-registry/src/tests/fixtures/graph_bad_supported_by/knowledge/not_a_bkm.md
+++ b/type-registry/src/tests/fixtures/graph_bad_supported_by/knowledge/not_a_bkm.md
@@ -1,0 +1,7 @@
+---
+dmn:
+  id: not_a_bkm
+  type: knowledge-source
+  name: Not A BKM
+  uri: https://example.com
+---

--- a/type-registry/src/tests/fixtures/graph_cycle/decisions/a.md
+++ b/type-registry/src/tests/fixtures/graph_cycle/decisions/a.md
@@ -1,0 +1,8 @@
+---
+dmn:
+  id: decision_a
+  type: decision
+  name: Decision A
+  requires:
+    - decision_b
+---

--- a/type-registry/src/tests/fixtures/graph_cycle/decisions/b.md
+++ b/type-registry/src/tests/fixtures/graph_cycle/decisions/b.md
@@ -1,0 +1,8 @@
+---
+dmn:
+  id: decision_b
+  type: decision
+  name: Decision B
+  requires:
+    - decision_a
+---

--- a/type-registry/src/tests/fixtures/graph_governed_by/decisions/pricing.md
+++ b/type-registry/src/tests/fixtures/graph_governed_by/decisions/pricing.md
@@ -1,0 +1,10 @@
+---
+dmn:
+  id: pricing
+  type: decision
+  name: Pricing
+  requires:
+    - customer
+  governed-by:
+    - regulations
+---

--- a/type-registry/src/tests/fixtures/graph_governed_by/inputs/customer.md
+++ b/type-registry/src/tests/fixtures/graph_governed_by/inputs/customer.md
@@ -1,0 +1,6 @@
+---
+dmn:
+  id: customer
+  type: input-data
+  name: Customer
+---

--- a/type-registry/src/tests/fixtures/graph_governed_by/regulatory/regulations.md
+++ b/type-registry/src/tests/fixtures/graph_governed_by/regulatory/regulations.md
@@ -1,0 +1,7 @@
+---
+dmn:
+  id: regulations
+  type: knowledge-source
+  name: Regulations
+  uri: https://example.com/regs
+---

--- a/type-registry/src/tests/fixtures/graph_missing_link/decisions/orphan.md
+++ b/type-registry/src/tests/fixtures/graph_missing_link/decisions/orphan.md
@@ -1,0 +1,8 @@
+---
+dmn:
+  id: orphan_decision
+  type: decision
+  name: Orphan Decision
+  requires:
+    - does_not_exist
+---

--- a/type-registry/src/tests/fixtures/graph_simple/decisions/eligibility.md
+++ b/type-registry/src/tests/fixtures/graph_simple/decisions/eligibility.md
@@ -1,0 +1,15 @@
+---
+dmn:
+  id: eligibility
+  type: decision
+  name: Eligibility
+  requires:
+    - applicant
+    - loan_amount
+---
+
+| U  | Age | Loan Amount | Eligible |
+|:--:|:---:|:-----------:|:--------:|
+|    | in  | in          | out      |
+| 1  | >=18| <=500000    | true     |
+| 2  | -   | -           | false    |

--- a/type-registry/src/tests/fixtures/graph_simple/inputs/applicant.md
+++ b/type-registry/src/tests/fixtures/graph_simple/inputs/applicant.md
@@ -1,0 +1,6 @@
+---
+dmn:
+  id: applicant
+  type: input-data
+  name: Applicant
+---

--- a/type-registry/src/tests/fixtures/graph_simple/inputs/loan_amount.md
+++ b/type-registry/src/tests/fixtures/graph_simple/inputs/loan_amount.md
@@ -1,0 +1,6 @@
+---
+dmn:
+  id: loan_amount
+  type: input-data
+  name: Loan Amount
+---

--- a/type-registry/src/tests/mod.rs
+++ b/type-registry/src/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod test_exporter;
 mod test_front_matter;
+mod test_graph;
 mod test_json_schema;
 mod test_loan_pricing;
 mod test_loan_pricing_e2e;

--- a/type-registry/src/tests/test_graph.rs
+++ b/type-registry/src/tests/test_graph.rs
@@ -80,9 +80,18 @@ fn _0008() {
   assert!(msg.contains("knowledge-source"), "expected 'knowledge-source' in error: {msg}");
 }
 
-/// The loan_pricing fixture builds a valid DRG with multiple node types and edge kinds.
+/// supported-by pointing to a knowledge-source (not bkm) fails.
 #[test]
 fn _0009() {
+  let result = build_drg(&fixture_path("graph_bad_supported_by"));
+  assert!(result.is_err());
+  let msg = result.unwrap_err().to_string();
+  assert!(msg.contains("bkm"), "expected 'bkm' in error: {msg}");
+}
+
+/// The loan_pricing fixture builds a valid DRG with multiple node types and edge kinds.
+#[test]
+fn _0010() {
   let drg = build_drg(&fixture_path("loan_pricing")).unwrap();
   assert!(drg.node_count() >= 3, "expected at least 3 nodes, got {}", drg.node_count());
   let order = drg.topological_order().unwrap();

--- a/type-registry/src/tests/test_graph.rs
+++ b/type-registry/src/tests/test_graph.rs
@@ -1,0 +1,90 @@
+use crate::graph::{build_drg, DrgEdgeKind};
+use std::path::PathBuf;
+
+fn fixture_path(name: &str) -> PathBuf {
+  PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests/fixtures").join(name)
+}
+
+/// A valid 3-node project produces a graph with 3 nodes and 2 edges.
+#[test]
+fn _0001() {
+  let drg = build_drg(&fixture_path("graph_simple")).unwrap();
+  assert_eq!(drg.node_count(), 3);
+  assert_eq!(drg.edge_count(), 2);
+}
+
+/// All edge kinds in the simple fixture are InformationRequirement.
+#[test]
+fn _0002() {
+  let drg = build_drg(&fixture_path("graph_simple")).unwrap();
+  for edge in drg.edge_kinds() {
+    assert_eq!(edge, DrgEdgeKind::InformationRequirement);
+  }
+}
+
+/// Topological order puts inputs before decisions.
+#[test]
+fn _0003() {
+  let drg = build_drg(&fixture_path("graph_simple")).unwrap();
+  let order = drg.topological_order().unwrap();
+  let eligibility_pos = order.iter().position(|id| id == "eligibility").unwrap();
+  let applicant_pos = order.iter().position(|id| id == "applicant").unwrap();
+  let loan_pos = order.iter().position(|id| id == "loan_amount").unwrap();
+  assert!(applicant_pos < eligibility_pos);
+  assert!(loan_pos < eligibility_pos);
+}
+
+/// A project with a cycle returns an error containing "cycle".
+#[test]
+fn _0004() {
+  let result = build_drg(&fixture_path("graph_cycle"));
+  assert!(result.is_err());
+  let msg = result.unwrap_err().to_string();
+  assert!(msg.contains("cycle"), "expected 'cycle' in error: {msg}");
+}
+
+/// A project with an unresolved link returns an error containing the target id.
+#[test]
+fn _0005() {
+  let result = build_drg(&fixture_path("graph_missing_link"));
+  assert!(result.is_err());
+  let msg = result.unwrap_err().to_string();
+  assert!(msg.contains("does_not_exist"), "expected 'does_not_exist' in error: {msg}");
+}
+
+/// An empty directory returns an error.
+#[test]
+fn _0006() {
+  let dir = std::env::temp_dir().join("dsntk_test_empty_drg");
+  let _ = std::fs::create_dir_all(&dir);
+  let result = build_drg(&dir);
+  assert!(result.is_err());
+  let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// governed-by pointing to a knowledge-source is valid.
+#[test]
+fn _0007() {
+  let drg = build_drg(&fixture_path("graph_governed_by")).unwrap();
+  assert_eq!(drg.node_count(), 3);
+  let ks_edges: Vec<_> = drg.edge_kinds().into_iter().filter(|k| *k == DrgEdgeKind::AuthorityRequirement).collect();
+  assert_eq!(ks_edges.len(), 1);
+}
+
+/// governed-by pointing to a decision (not knowledge-source) fails.
+#[test]
+fn _0008() {
+  let result = build_drg(&fixture_path("graph_bad_governed_by"));
+  assert!(result.is_err());
+  let msg = result.unwrap_err().to_string();
+  assert!(msg.contains("knowledge-source"), "expected 'knowledge-source' in error: {msg}");
+}
+
+/// The loan_pricing fixture builds a valid DRG with multiple node types and edge kinds.
+#[test]
+fn _0009() {
+  let drg = build_drg(&fixture_path("loan_pricing")).unwrap();
+  assert!(drg.node_count() >= 3, "expected at least 3 nodes, got {}", drg.node_count());
+  let order = drg.topological_order().unwrap();
+  assert_eq!(order.len(), drg.node_count());
+}


### PR DESCRIPTION
## Summary

- Add `graph` module to `dsntk-type-registry` that builds a Decision Requirements Graph (DRG) from markdown DMN project files using petgraph
- Validates: acyclicity, unresolved links, duplicate node IDs, edge-type constraints (governed-by → knowledge-source, supported-by → bkm)
- Produces topological evaluation order (inputs first, terminal decisions last)
- Add `dsntk val <DIR>` CLI command for project validation

## Details

Implements Spec 1 (DRG Construction & Validation) from issue #6.

**New files:**
- `type-registry/src/graph.rs` — core DRG module (191 lines)
- `type-registry/src/tests/test_graph.rs` — 10 tests across 5 fixture projects

**Modified files:**
- `type-registry/src/errors.rs` — 6 new error constructors
- `dsntk/src/actions.rs` — `dsntk val` subcommand

**Example output:**
```
$ dsntk val /tmp/loan-eligibility
Project is valid.
  Nodes: 3
  Edges: 3
  Evaluation order:
    1. applicant_input
    2. risk_rating
    3. loan_eligibility
```

## Test plan

- [x] 10 new graph tests pass (valid DAG, edge kinds, topological order, cycles, missing links, empty dirs, governed-by/supported-by validation, loan_pricing fixture)
- [x] All 175 type-registry tests pass
- [x] Full workspace tests pass
- [x] Clippy clean
- [x] Smoke tested with `dsntk new` + `dsntk val`

🤖 Generated with [Claude Code](https://claude.com/claude-code)